### PR TITLE
Fix theme/language toggles hidden in mobile menu

### DIFF
--- a/style.css
+++ b/style.css
@@ -970,8 +970,10 @@ html[data-theme="dark"] .hero-figure img { filter: grayscale(0.15) brightness(0.
     padding: 24px var(--edge) 32px;
     transform: translateY(-100%);
     transition: transform 0.25s ease;
+    overflow-y: auto;
   }
   .sidebar.open { transform: translateY(0); }
+  .sidebar-controls { margin-top: 24px; }
 
   .mobile-bar {
     display: flex;


### PR DESCRIPTION
On mobile the sidebar had no overflow-y set, so the sidebar-controls
(anchored to the flex bottom via margin-top:auto) were pushed off-screen
and unreachable. Added overflow-y:auto to make the sidebar scrollable,
and overrode margin-top:auto with a fixed 24px gap so the controls sit
immediately below the nav groups without requiring a scroll.

https://claude.ai/code/session_01EHuz5n9YY7P9ieM6vtenc4