### PR TITLE
Fix theme/language toggles hidden in mobile menu

### DIFF
--- a/appearances/index.html
+++ b/appearances/index.html
@@ -15,7 +15,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@300;400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/style.css?v=2" />
+  <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
   <a class="skip-link" href="#page" data-i18n="skip">Skip to Content</a>
@@ -172,6 +172,6 @@
   </div>
 
   <script src="/app.js"></script>
-  <script src="/i18n.js?v=9"></script>
+  <script src="/i18n.js?v=10"></script>
 </body>
 </html>

--- a/appearances/index.html
+++ b/appearances/index.html
@@ -15,7 +15,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@300;400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/style.css" />
+  <link rel="stylesheet" href="/style.css?v=2" />
 </head>
 <body>
   <a class="skip-link" href="#page" data-i18n="skip">Skip to Content</a>

--- a/cea/index.html
+++ b/cea/index.html
@@ -15,7 +15,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@300;400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/style.css" />
+  <link rel="stylesheet" href="/style.css?v=2" />
 </head>
 <body>
   <a class="skip-link" href="#page" data-i18n="skip">Skip to Content</a>

--- a/cea/index.html
+++ b/cea/index.html
@@ -15,7 +15,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@300;400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/style.css?v=2" />
+  <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
   <a class="skip-link" href="#page" data-i18n="skip">Skip to Content</a>
@@ -182,6 +182,6 @@
   </div>
 
   <script src="/app.js"></script>
-  <script src="/i18n.js?v=9"></script>
+  <script src="/i18n.js?v=10"></script>
 </body>
 </html>

--- a/digital-transformation/index.html
+++ b/digital-transformation/index.html
@@ -15,7 +15,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@300;400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/style.css" />
+  <link rel="stylesheet" href="/style.css?v=2" />
 </head>
 <body>
   <a class="skip-link" href="#page" data-i18n="skip">Skip to Content</a>

--- a/digital-transformation/index.html
+++ b/digital-transformation/index.html
@@ -15,7 +15,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@300;400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/style.css?v=2" />
+  <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
   <a class="skip-link" href="#page" data-i18n="skip">Skip to Content</a>
@@ -169,6 +169,6 @@
   </div>
 
   <script src="/app.js"></script>
-  <script src="/i18n.js?v=9"></script>
+  <script src="/i18n.js?v=10"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@300;400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/style.css" />
+  <link rel="stylesheet" href="/style.css?v=2" />
 </head>
 <body>
   <a class="skip-link" href="#page" data-i18n="skip">Skip to Content</a>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@300;400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/style.css?v=2" />
+  <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
   <a class="skip-link" href="#page" data-i18n="skip">Skip to Content</a>
@@ -226,6 +226,6 @@
   </div>
 
   <script src="/app.js"></script>
-  <script src="/i18n.js?v=9"></script>
+  <script src="/i18n.js?v=10"></script>
 </body>
 </html>

--- a/innovation/index.html
+++ b/innovation/index.html
@@ -15,7 +15,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@300;400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/style.css?v=2" />
+  <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
   <a class="skip-link" href="#page" data-i18n="skip">Skip to Content</a>
@@ -172,6 +172,6 @@
   </div>
 
   <script src="/app.js"></script>
-  <script src="/i18n.js?v=9"></script>
+  <script src="/i18n.js?v=10"></script>
 </body>
 </html>

--- a/innovation/index.html
+++ b/innovation/index.html
@@ -15,7 +15,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@300;400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/style.css" />
+  <link rel="stylesheet" href="/style.css?v=2" />
 </head>
 <body>
   <a class="skip-link" href="#page" data-i18n="skip">Skip to Content</a>

--- a/open-source/index.html
+++ b/open-source/index.html
@@ -15,7 +15,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@300;400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/style.css" />
+  <link rel="stylesheet" href="/style.css?v=2" />
 </head>
 <body>
   <a class="skip-link" href="#page" data-i18n="skip">Skip to Content</a>

--- a/open-source/index.html
+++ b/open-source/index.html
@@ -15,7 +15,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@300;400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/style.css?v=2" />
+  <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
   <a class="skip-link" href="#page" data-i18n="skip">Skip to Content</a>
@@ -192,6 +192,6 @@
   </div>
 
   <script src="/app.js"></script>
-  <script src="/i18n.js?v=9"></script>
+  <script src="/i18n.js?v=10"></script>
 </body>
 </html>

--- a/publications/index.html
+++ b/publications/index.html
@@ -15,7 +15,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@300;400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/style.css?v=2" />
+  <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
   <a class="skip-link" href="#page" data-i18n="skip">Skip to Content</a>
@@ -164,6 +164,6 @@
   </div>
 
   <script src="/app.js"></script>
-  <script src="/i18n.js?v=9"></script>
+  <script src="/i18n.js?v=10"></script>
 </body>
 </html>

--- a/publications/index.html
+++ b/publications/index.html
@@ -15,7 +15,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@300;400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/style.css" />
+  <link rel="stylesheet" href="/style.css?v=2" />
 </head>
 <body>
   <a class="skip-link" href="#page" data-i18n="skip">Skip to Content</a>

--- a/superurbana/index.html
+++ b/superurbana/index.html
@@ -15,7 +15,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@300;400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/style.css" />
+  <link rel="stylesheet" href="/style.css?v=2" />
 </head>
 <body>
   <a class="skip-link" href="#page" data-i18n="skip">Skip to Content</a>

--- a/superurbana/index.html
+++ b/superurbana/index.html
@@ -15,7 +15,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@300;400;500;600&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/style.css?v=2" />
+  <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
   <a class="skip-link" href="#page" data-i18n="skip">Skip to Content</a>
@@ -166,6 +166,6 @@
   </div>
 
   <script src="/app.js"></script>
-  <script src="/i18n.js?v=9"></script>
+  <script src="/i18n.js?v=10"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Fixed the LIGHT/DARK and EN/DE toggles not appearing in the mobile sidebar menu
- Added `overflow-y: auto` to the mobile sidebar so its content is always scrollable
- Overrode `margin-top: auto` on `.sidebar-controls` with a fixed `24px` gap, so the toggles sit immediately below the nav links without requiring a scroll
- Bumped `i18n.js` to `?v=10` across all pages to bust browser caches

## Root cause

On mobile (≤900px) the sidebar is `position: fixed` with no `overflow-y` set. The `.sidebar-controls` div uses `margin-top: auto` to pin itself to the bottom of the flex column — which ends up below the visible viewport — and since the sidebar wasn't scrollable, users could never reach the toggles.

## Test plan

- [ ] Open the site on a mobile viewport (or DevTools at ≤900px)
- [ ] Tap **Menu** — sidebar slides in
- [ ] Confirm LIGHT/DARK and EN/DE toggles are visible without scrolling
- [ ] Toggle dark mode — page switches correctly
- [ ] Toggle language — page switches to German/English
- [ ] Verify desktop layout is unchanged (no regression)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHuz5n9YY7P9ieM6vtenc4)_