### PR TITLE
Fix theme/language toggles hidden in mobile menu

### DIFF
--- a/style.css
+++ b/style.css
@@ -962,9 +962,8 @@ html[data-theme="dark"] .hero-figure img { filter: grayscale(0.15) brightness(0.
 
   .sidebar {
     position: fixed;
-    top: 0; left: 0; right: 0;
-    height: auto;
-    min-height: 100vh;
+    top: 0; left: 0; right: 0; bottom: 0;
+    height: 100vh;
     background: var(--bg);
     z-index: 50;
     padding: 24px var(--edge) 32px;


### PR DESCRIPTION
## Summary

- Fixed the LIGHT/DARK and EN/DE toggles not appearing in the mobile sidebar menu
- Changed mobile sidebar from `height: auto; min-height: 100vh` to `height: 100vh; bottom: 0` so the sidebar has a definite height and `overflow-y: auto` actually creates a scrollbar when content exceeds the viewport
- Overrode `margin-top: auto` on `.sidebar-controls` with `24px` so toggles sit right below nav links
- Bumped `i18n.js` to `?v=10` across all pages to bust browser caches

## Root cause

On mobile (≤900px), the sidebar had `position: fixed; height: auto; min-height: 100vh`. The nav content plus controls exceeded the viewport height on smaller screens, but because `height: auto` means the element just grows — never overflows — `overflow-y: auto` had no effect. The controls at the bottom were pushed past the viewport edge with no way to scroll to them.

## Test plan

- [ ] Open site on a mobile viewport (or DevTools ≤ 400px width)
- [ ] Tap **Menu** — sidebar slides in
- [ ] Scroll within sidebar if content is taller than viewport
- [ ] Confirm LIGHT/DARK and EN/DE toggles are visible and functional
- [ ] Verify desktop layout is unchanged (no regression)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHuz5n9YY7P9ieM6vtenc4)_